### PR TITLE
Support Multiple Versions

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -112,15 +112,18 @@ if [ ! -z "$(echo $ELASTICSEARCH_URL | egrep '://[a-zA-Z0-9]{1,}:[a-zA-Z0-9]{1,}
   PWORD="$(echo $ELASTICSEARCH_URL | egrep '://[a-zA-Z0-9]{1,}:[a-zA-Z0-9]{1,}@' | sed -E 's/.*:\/\/([a-zA-Z0-9]{1,}):([a-zA-Z0-9]{1,}).*/\2/')"
 fi
 
-ENCODED_AUTH="whoo"
+
 KIBANA_CONF="${CACHE_DIR}/kibana.yml"
 
-echo "elasticsearch.url: ${ELASTICSEARCH_URL}" > $KIBANA_CONF
+# Heroku doesn't like the default of localhost
+echo "server.host: 0.0.0.0" > $KIBANA_CONF
+echo "elasticsearch.url: ${ELASTICSEARCH_URL}" >> $KIBANA_CONF
 
 if [ $UNAME != "" ]; then
   echo "elasticsearch.username: ${UNAME}" >> $KIBANA_CONF
   echo "elasticsearch.password: ${PWORD}" >> $KIBANA_CONF
   if [ "$(major_version)" -ge "6" ]; then
+    ENCODED_AUTH=$(echo -n ${UNAME}:${PWORD} | base64)
     echo "elasticsearch.customHeaders: { Authorization: basic $ENCODED_AUTH }" >> $KIBANA_CONF
     echo "elasticsearch.requestHeadersWhitelist: []" >> $KIBANA_CONF
   fi

--- a/bin/compile
+++ b/bin/compile
@@ -123,9 +123,7 @@ if [ $UNAME != "" ]; then
   echo "elasticsearch.username: ${UNAME}" >> $KIBANA_CONF
   echo "elasticsearch.password: ${PWORD}" >> $KIBANA_CONF
   if [ "$(major_version)" -ge "6" ]; then
-    ENCODED_AUTH=$(echo -n ${UNAME}:${PWORD} | base64)
-    echo "elasticsearch.customHeaders: { Authorization: basic $ENCODED_AUTH }" >> $KIBANA_CONF
-    echo "elasticsearch.requestHeadersWhitelist: []" >> $KIBANA_CONF
+    echo "elasticsearch.requestHeadersWhitelist: [ authorization ]"
   fi
 fi
 

--- a/bin/compile
+++ b/bin/compile
@@ -123,7 +123,7 @@ if [ $UNAME != "" ]; then
   echo "elasticsearch.username: ${UNAME}" >> $KIBANA_CONF
   echo "elasticsearch.password: ${PWORD}" >> $KIBANA_CONF
   if [ "$(major_version)" -ge "6" ]; then
-    echo "elasticsearch.requestHeadersWhitelist: [ authorization ]"
+    echo "elasticsearch.requestHeadersWhitelist: [ authorization ]" >> $KIBANA_CONF
   fi
 fi
 

--- a/bin/compile
+++ b/bin/compile
@@ -1,7 +1,28 @@
-#!/bin/sh
+#!/bin/bash
 
 indent() {
   sed -u 's/^/       /'
+}
+
+function major_version() {
+  echo $ELASTICSEARCH_VERSION | cut -d . -f 1
+}
+
+function minor_version() {
+  echo $ELASTICSEARCH_VERSION | cut -d . -f 2
+}
+
+# if version >= 6.3, choose oss or x-pack depending on elasticsearch build from sniff
+function download_url() {
+  if [ "$(major_version)" -ge "6" ] && [ "$(minor_version)" -ge "3" ]; then
+    if [ $ELASTICSEARCH_FLAVOR == "oss" ]; then
+      echo "https://artifacts.elastic.co/downloads/kibana/kibana-oss-${ELASTICSEARCH_VERSION}-linux-x86_64.tar.gz"
+    else
+      echo "https://artifacts.elastic.co/downloads/kibana/kibana-${ELASTICSEARCH_VERSION}-linux-x86_64.tar.gz"
+    fi
+  else
+    echo "https://artifacts.elastic.co/downloads/kibana/kibana-${ELASTICSEARCH_VERSION}-linux-x86_64.tar.gz"
+  fi
 }
 
 BUILD_DIR=$1
@@ -24,58 +45,54 @@ else
   ELASTICSEARCH_URL="http://localhost:9200"
 fi
 
-# Check for username/password
-if [ ! -z "$(echo $ELASTICSEARCH_URL | egrep '://[a-zA-Z0-9]{1,}:[a-zA-Z0-9]{1,}@')" ]; then
-  UNAME="$(echo $ELASTICSEARCH_URL | egrep '://[a-zA-Z0-9]{1,}:[a-zA-Z0-9]{1,}@' | sed -E 's/.*:\/\/([a-zA-Z0-9]{1,}):([a-zA-Z0-9]{1,}).*/\1/')"
-  PWORD="$(echo $ELASTICSEARCH_URL | egrep '://[a-zA-Z0-9]{1,}:[a-zA-Z0-9]{1,}@' | sed -E 's/.*:\/\/([a-zA-Z0-9]{1,}):([a-zA-Z0-9]{1,}).*/\2/')"
+# Query the ES URL and extract the version
+DETAILS=$(curl -s $ELASTICSEARCH_URL)
+
+if [ $? -ne 0 ]; then
+  echo "Unable to access $ELASTICSEARCH_URL, cannot install Kibana"
+  exit 1
 fi
 
-if [ -f "$ENV_DIR/DOWNLOAD_URL" ]; then
-  DOWNLOAD_URL=$(cat $ENV_DIR/DOWNLOAD_URL)
-else
-  DOWNLOAD_URL="https://artifacts.elastic.co/downloads/kibana/kibana-5.4.3-linux-x86_64.tar.gz"
-fi
+# Extract the version and flavor
+ELASTICSEARCH_VERSION=$(echo $DETAILS | grep -m1 -oP '"number"\s*:\s*"\K[^"]+')
+ELASTICSEARCH_FLAVOR=$(echo $DETAILS | grep -m1 -oP '"build_flavor"\s*:\s*"\K[^"]+')
+
+# Compose a URL to fetch kibana
+DOWNLOAD_URL=$(download_url)
 
 KIBANA_PACKAGE=${DOWNLOAD_URL##*/}
-
 case ${KIBANA_PACKAGE} in
   *.tar.gz)
-    KIBANA_DIR="$BUILD_DIR/${KIBANA_PACKAGE%%.tar.gz}"
-    tar="tar xz"
     ;;
   *)
     echo "Only tar.gz is supported: $KIBANA_PACKAGE" | indent
     exit 1
     ;;
 esac
+KIBANA_DIR="$BUILD_DIR/kibana-${ELASTICSEARCH_VERSION}-linux-x86_64"
 
-mkdir="mkdir -p"
-download="curl -sLO"
-extract="$tar -C $BUILD_DIR --wildcards -f"
-verify="sha1sum --check --warn"
-configure='sed -i s/^\x23\(elasticsearch.url:\x20\).\{1,\}/\1"'$(echo $ELASTICSEARCH_URL | sed 's/\//\\\//g')'"/'
-configure_user='sed -i s/^\x23\(elasticsearch.username:\x20\).\{1,\}/\1"'$(echo $UNAME | sed 's/\//\\\//g')'"/'
-configure_pass='sed -i s/^\x23\(elasticsearch.password:\x20\).\{1,\}/\1"'$(echo $PWORD | sed 's/\//\\\//g')'"/'
-configure_host='sed -i s/^\x23\(server.host:\x20\).\{1,\}/\10.0.0.0/'
-show_config='egrep "^\[^\x23\]"'
+echo "-----> Installing Kibana ${KIBANA_PACKAGE}..."
 
-echo "-----> Installing Kibana..."
-
-$mkdir ${INIT_SCRIPT%/*}
-$mkdir $CACHE_DIR
+mkdir -p ${INIT_SCRIPT%/*}
+mkdir -p $CACHE_DIR
 
 if [ ! -f "$CACHE_DIR/$KIBANA_PACKAGE" ]; then
 
-  echo "downloading $KIBANA_PACKAGE from $DOWNLOAD_URL" | indent
-  $download $DOWNLOAD_URL
+  echo "Downloading $KIBANA_PACKAGE from $DOWNLOAD_URL" | indent
+  curl -sLO $DOWNLOAD_URL
 
-  echo "verifying against ${DOWNLOAD_URL}.sha1" | indent
-  $download "${DOWNLOAD_URL}.sha1"
-  echo "$(cat ${KIBANA_PACKAGE}.sha1) *${KIBANA_PACKAGE}" > ${KIBANA_PACKAGE}.sha1
-  echo "Contents of the SHA1: " | indent
-  cat ${KIBANA_PACKAGE}.sha1
+  if [ $? -ne 0 ]; then
+    echo "Unable to fetch $DOWNLOAD_URL, cannot install Kibana"
+    exit 1
+  fi
 
-  $verify "${KIBANA_PACKAGE}.sha1"
+  # echo "Verifying against ${DOWNLOAD_URL}.sha1" | indent
+  # curl -sLO "${DOWNLOAD_URL}.sha1"
+  # echo "$(cat ${KIBANA_PACKAGE}.sha1) *${KIBANA_PACKAGE}" > ${KIBANA_PACKAGE}.sha1
+  # echo "Contents of the SHA1: " | indent
+  # cat ${KIBANA_PACKAGE}.sha1
+
+  # sha1sum --check --warn "${KIBANA_PACKAGE}.sha1"
 
   if [ $? -eq 0 ]; then
     mv $KIBANA_PACKAGE $CACHE_DIR
@@ -84,20 +101,38 @@ if [ ! -f "$CACHE_DIR/$KIBANA_PACKAGE" ]; then
   fi
 fi
 
-$extract $CACHE_DIR/$KIBANA_PACKAGE
+echo "-----> Extracting Kibana ${KIBANA_PACKAGE}..."
+tar xz -C $BUILD_DIR --wildcards -f $CACHE_DIR/$KIBANA_PACKAGE
 
-echo "-----> Configuring ELASTICSEARCH_URL"
-$configure $KIBANA_DIR/config/kibana.yml
-$configure_host $KIBANA_DIR/config/kibana.yml
-echo "$(grep 'elasticsearch.url' $KIBANA_DIR/config/kibana.yml)" | indent
+echo "-----> Configuring Kibana @ ${KIBANA_DIR}..."
+
+# Check for username/password
 if [ ! -z "$(echo $ELASTICSEARCH_URL | egrep '://[a-zA-Z0-9]{1,}:[a-zA-Z0-9]{1,}@')" ]; then
-  echo "Updating the authentication credentials" | indent
-  $configure_user $KIBANA_DIR/config/kibana.yml
-  $configure_pass $KIBANA_DIR/config/kibana.yml
+  UNAME="$(echo $ELASTICSEARCH_URL | egrep '://[a-zA-Z0-9]{1,}:[a-zA-Z0-9]{1,}@' | sed -E 's/.*:\/\/([a-zA-Z0-9]{1,}):([a-zA-Z0-9]{1,}).*/\1/')"
+  PWORD="$(echo $ELASTICSEARCH_URL | egrep '://[a-zA-Z0-9]{1,}:[a-zA-Z0-9]{1,}@' | sed -E 's/.*:\/\/([a-zA-Z0-9]{1,}):([a-zA-Z0-9]{1,}).*/\2/')"
 fi
 
-echo "Configuration settings applied:" | indent
-echo "$(egrep '^[^#]' $KIBANA_DIR/config/kibana.yml)" | indent
+ENCODED_AUTH="whoo"
+KIBANA_CONF="${CACHE_DIR}/kibana.yml"
 
-echo "Exporting PATH" | indent
+echo "elasticsearch.url: ${ELASTICSEARCH_URL}" > $KIBANA_CONF
+
+if [ $UNAME != "" ]; then
+  echo "elasticsearch.username: ${UNAME}" >> $KIBANA_CONF
+  echo "elasticsearch.password: ${PWORD}" >> $KIBANA_CONF
+  if [ "$(major_version)" -ge "6" ]; then
+    echo "elasticsearch.customHeaders: { Authorization: basic $ENCODED_AUTH }" >> $KIBANA_CONF
+    echo "elasticsearch.requestHeadersWhitelist: []" >> $KIBANA_CONF
+  fi
+fi
+
+echo "-----> Configured Kibana"
+echo
+cat $KIBANA_CONF
+echo
+
+echo "-----> Applying configuration"
+mv -v $KIBANA_CONF $KIBANA_DIR/config/kibana.yml
+
+echo "-----> Exporting Path"
 echo 'export PATH="$PATH:'${KIBANA_DIR##*/}'/bin"' > $INIT_SCRIPT

--- a/readme.md
+++ b/readme.md
@@ -15,20 +15,18 @@ See our other repo at https://github.com/omc/heroku-kibana for a one-click deplo
 Or, to use as a standalone buildpack:
 
     # Create a new project with the --buildpack option
-    $ heroku create --buildpack https://github.com/omc/heroku-buildpack-kibana
-
-    # ...Or update an existing project with heroku buildpacks:set
-    $ heroku buildpacks:set https://github.com/omc/heroku-buildpack-kibana
+    $ mkdir kibana1 && cd kibana1 && git init
+    $ heroku create kibana1 --buildpack https://github.com/omc/heroku-buildpack-kibana
 
     # Let Kibana know where to find Elasticsearch
     $ heroku config:set ELASTICSEARCH_URL="https://kibanauser:kibanapass@host.region.bonsaisearch.net"
 
     # Create a Procfile to run the Kibana web server
-    $ cat Procfile
-    web: kibana --port $PORT
+    $ echo 'web: kibana --port $PORT' > Procfile
 
     # Push the above to trigger a deploy
-    $ git push heroku master
+    $ git add . && git commit -am "Kibana setup" && git push heroku master
 
-    # Verify and profit!
+    # Open the app in your browser.  You may be prompted for a username/password, which
+    # matches the username and password of your elasticsearch URL.
     $ heroku open

--- a/readme.md
+++ b/readme.md
@@ -6,7 +6,7 @@ For a one-click deploy of Kibana on Heroku, see [omc/heroku-kibana](https://gith
 
 ## Compatibility
 
-Tested against Kibana 4.1.2.
+Tested versions: 5.x.y -> 6.x.y
 
 ## Usage
 
@@ -20,11 +20,8 @@ Or, to use as a standalone buildpack:
     # ...Or update an existing project with heroku buildpacks:set
     $ heroku buildpacks:set https://github.com/omc/heroku-buildpack-kibana
 
-    # Let the buildpack know where to find Kibana
-    $ heroku config:set DOWNLOAD_URL="https://download.elastic.co/kibana/kibana/kibana-4.1.2-linux-x64.tar.gz"
-
     # Let Kibana know where to find Elasticsearch
-    $ heroku config:set ELASTICSEARCH_URL="https://kibanauser:kibanapass@host.region.bonsai.io"
+    $ heroku config:set ELASTICSEARCH_URL="https://kibanauser:kibanapass@host.region.bonsaisearch.net"
 
     # Create a Procfile to run the Kibana web server
     $ cat Procfile


### PR DESCRIPTION
This change set adds support for sniffing the version of ES at compile time.  This makes it possible to setup kibana for multiple versions of ES.  It also takes into account oss vs x-pack builds for 6.3+.